### PR TITLE
Modified to use a compact memory structure for the nodes and edges. A…

### DIFF
--- a/list.go
+++ b/list.go
@@ -2,7 +2,7 @@ package graphblog
 
 type listElt struct {
 	next *listElt
-	node *node
+	node nodeId
 }
 
 type list struct {
@@ -12,10 +12,10 @@ type list struct {
 	free *listElt
 }
 
-func (l *list) getHead() *node {
+func (l *list) getHead() nodeId {
 	elt := l.head
 	if elt == nil {
-		return nil
+		return -1
 	}
 
 	// Remove elt from the list
@@ -28,11 +28,11 @@ func (l *list) getHead() *node {
 	l.free = elt
 
 	n := elt.node
-	elt.node = nil
+	elt.node = -1
 	return n
 }
 
-func (l *list) pushBack(n *node) {
+func (l *list) pushBack(n nodeId) {
 	// Get a free listElt to use to point to this node
 	elt := l.free
 	if elt == nil {

--- a/node_test.go
+++ b/node_test.go
@@ -1,12 +1,10 @@
 package graphblog
 
 import (
-	"os"
-	"testing"
-
 	"bufio"
-
+	"os"
 	"strings"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -66,7 +64,8 @@ func TestDiameter(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			g := New(100)
 			test.edgeList.build(g)
-			dia := g.diameter()
+			g2 := g.convertToMemoryOptimisedGraph()
+			dia := g2.diameter()
 			if dia != test.expDiameter {
 				t.Errorf("Diameter not as expected. Have %d, expected %d", dia, test.expDiameter)
 			}
@@ -88,10 +87,12 @@ func BenchmarkDiameter(b *testing.B) {
 	}
 	assert.NoError(b, err)
 
+	g2 := g.convertToMemoryOptimisedGraph()
+
 	b.Run("diameter", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			d := g.diameter()
+			d := g2.diameter()
 			assert.Equal(b, 82, d)
 		}
 	})


### PR DESCRIPTION
No change to algorithm just the memory structures used to represent the node and edges.

Based on efficient memory structures outlined here https://www.ibm.com/developerworks/community/blogs/jfp/entry/memory_locality?lang=en
 
Used nodeId rather than *node in the queue. Also reordered the memory to reflect traversal order.

I seem to get variable times depending on the CPU type I run this on but approx 30% improvement from your last version. 